### PR TITLE
feat: specify map panes with zIndex properties

### DIFF
--- a/modules/map.py
+++ b/modules/map.py
@@ -61,14 +61,17 @@ def map_server(input, output, session, is_wb_data):
         no_wrap=True,
         layout=Layout(width="100%", height="100%"),
     )
+    map.panes = {"circles": {"zIndex": 650}, "choropleth": {"zIndex": 750}}
     register_widget("map", map)
 
     # Circles Layer will later be filled with circleMarkers
     circle_markers_layer = LayerGroup()
+    circle_markers_layer.pane = "circles"
     map.add_layer(circle_markers_layer)
 
     # Polygon layer will later be filled reactively
     choropleth_layer = LayerGroup()
+    choropleth_layer.pane = "choropleth"
     map.add_layer(choropleth_layer)
 
     @reactive.Calc


### PR DESCRIPTION
Issue #25 

## Changes description
Specify zIndex for each layer on the map, to make sure that the layer with circle markers is always on top of the layer with polygons. This is important to ensure clickability of circle markers to create popups.